### PR TITLE
rfc: async api for persistent facts

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -298,7 +298,7 @@ export interface Transactor {
 }
 
 export interface Querier {
-  facts(selector?: FactsSelector): Iterable<Fact>
+  facts(selector?: FactsSelector): Promise<Iterable<Fact>>
 }
 
 export type Constraint = Variant<{

--- a/src/memory.js
+++ b/src/memory.js
@@ -129,8 +129,9 @@ class Memory {
 
   /**
    * @param {API.FactsSelector} selector
+   * @returns {Promise<Iterable<API.Fact>>}
    */
-  facts({ entity, attribute, value }) {
+  async facts({ entity, attribute, value }) {
     const key = toKey([entity ?? null, attribute ?? null, value ?? null])
     return this.model.index[key.toString()] ?? []
   }

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -74,9 +74,9 @@ class Query {
   /**
    *
    * @param {API.Querier} db
-   * @returns {API.InferBindings<Selection>[]}
+   * @returns {Promise<API.InferBindings<Selection>[]>}
    */
-  execute(db) {
-    return query(db, this.model)
+  async execute(db) {
+    return await query(db, this.model)
   }
 }

--- a/test/constraint.spec.js
+++ b/test/constraint.spec.js
@@ -12,11 +12,11 @@ const db = DB.Memory.create([
  * @type {import('entail').Suite}
  */
 export const testConstraints = {
-  like: (assert) => {
+  like: async (assert) => {
     const word = DB.string()
 
     // assert.deepEqual(
-    //   DB.query(db, {
+    //   await DB.query(db, {
     //     select: {
     //       word,
     //     },
@@ -26,7 +26,7 @@ export const testConstraints = {
     // )
 
     // assert.deepEqual(
-    //   DB.query(db, {
+    //   await DB.query(db, {
     //     select: {
     //       word,
     //     },
@@ -36,7 +36,7 @@ export const testConstraints = {
     // )
 
     // assert.deepEqual(
-    //   DB.query(db, {
+    //   await DB.query(db, {
     //     select: {
     //       word,
     //     },
@@ -46,7 +46,7 @@ export const testConstraints = {
     // )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -56,11 +56,11 @@ export const testConstraints = {
     )
   },
 
-  glob: (assert) => {
+  glob: async (assert) => {
     const word = DB.string()
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -71,7 +71,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -82,7 +82,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -93,7 +93,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -104,7 +104,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -115,7 +115,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -125,7 +125,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -141,7 +141,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -152,7 +152,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },

--- a/test/implicit.spec.js
+++ b/test/implicit.spec.js
@@ -15,7 +15,7 @@ export const testImplicit = {
     const expiration = DB.integer()
     const revoked = DB._
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         space,
         can,

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -18,7 +18,7 @@ export const testDB = {
     const uploadAdd = DB.link()
     const storeAdd = DB.link()
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         uploadCID,
         storeCID,
@@ -59,7 +59,7 @@ export const testDB = {
     const e = DB.link()
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: { e },
         where: [DB.match([e, 'age', 42])],
       }),
@@ -68,7 +68,7 @@ export const testDB = {
 
     const x = DB.string()
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: { x },
         where: [DB.match([DB._, 'likes', x])],
       }),
@@ -76,7 +76,7 @@ export const testDB = {
     )
   },
 
-  'sketch pull pattern': (assert) => {
+  'sketch pull pattern': async (assert) => {
     const Person = DB.entity({
       'person/name': DB.string,
     })
@@ -92,7 +92,7 @@ export const testDB = {
     const actor = new Person()
 
     assert.deepEqual(
-      DB.query(moviesDB, {
+      await DB.query(moviesDB, {
         select: {
           director: director['person/name'],
           movie: movie['movie/title'],
@@ -116,7 +116,7 @@ export const testDB = {
     )
 
     assert.deepEqual(
-      DB.query(moviesDB, {
+      await DB.query(moviesDB, {
         select: {
           director: director['person/name'],
           movie: movie['movie/title'],
@@ -145,7 +145,7 @@ export const testDB = {
     const directorName = DB.string()
     const movieTitle = DB.string()
 
-    const matches = DB.query(moviesDB, {
+    const matches = await DB.query(moviesDB, {
       select: {
         director: directorName,
         movie: movieTitle,
@@ -177,7 +177,7 @@ export const testDB = {
   'test facts': async (assert) => {
     const id = DB.link()
     const name = DB.string()
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name,
       },
@@ -198,7 +198,7 @@ export const testDB = {
     const supervisorName = DB.string()
     const employee = DB.link()
     const employeeName = DB.string()
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         employee: employeeName,
         supervisor: supervisorName,
@@ -232,7 +232,7 @@ export const testDB = {
       salary: DB.integer(),
     }
 
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         salary: employee.salary,
@@ -255,7 +255,7 @@ export const testDB = {
       ]
     )
 
-    const matches2 = DB.query(employeeDB, {
+    const matches2 = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         salary: employee.salary,
@@ -291,7 +291,7 @@ export const testDB = {
       name: DB.string(),
     }
 
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         supervisor: supervisor.name,
@@ -337,7 +337,7 @@ export const testDB = {
     }
 
     // finds all people supervised by Ben Bitdiddle who are not computer programmers
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
       },

--- a/test/predicates.spec.js
+++ b/test/predicates.spec.js
@@ -6,14 +6,14 @@ import { startsWith } from '../src/constraint.js'
  * @type {import('entail').Suite}
  */
 export const testMore = {
-  'test facts': (assert) => {
+  'test facts': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       job: DB.string,
     })
 
     const employee = new Employee()
-    const result = DB.query(testDB, {
+    const result = await DB.query(testDB, {
       select: {
         name: employee.name,
       },
@@ -25,7 +25,7 @@ export const testMore = {
     ])
 
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           name: employee.name,
           job: employee.job,
@@ -44,7 +44,7 @@ export const testMore = {
       ]
     )
   },
-  'test supervisor': (assert) => {
+  'test supervisor': async (assert) => {
     const Supervisor = DB.entity({
       name: DB.string,
       salary: DB.link,
@@ -59,7 +59,7 @@ export const testMore = {
     const employee = new Employee()
     const supervisor = new Supervisor()
 
-    const result = DB.query(testDB, {
+    const result = await DB.query(testDB, {
       select: {
         employee: employee.name,
         supervisor: supervisor.name,
@@ -78,7 +78,7 @@ export const testMore = {
       { employee: 'Aull DeWitt', supervisor: 'Warbucks Oliver' },
     ])
   },
-  'test salary': (assert) => {
+  'test salary': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       salary: DB.integer,
@@ -94,7 +94,7 @@ export const testMore = {
       where: [employee.salary.greater(30_000)],
     }
 
-    const result = DB.query(testDB, query)
+    const result = await DB.query(testDB, query)
 
     assert.deepEqual(result, [
       { name: 'Bitdiddle Ben', salary: 60_000 },
@@ -104,7 +104,7 @@ export const testMore = {
       { name: 'Scrooge Eben', salary: 75_000 },
     ])
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           name: employee.name,
           salary: employee.salary,
@@ -119,7 +119,7 @@ export const testMore = {
       ]
     )
   },
-  'test address': (assert) => {
+  'test address': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       address: DB.string,
@@ -137,12 +137,12 @@ export const testMore = {
       ],
     }
 
-    assert.deepEqual(DB.query(testDB, whoLivesInCambridge), [
+    assert.deepEqual(await DB.query(testDB, whoLivesInCambridge), [
       { name: 'Hacker Alyssa P', address: 'Campridge, Mass Ave 78' },
       { name: 'Fect Cy D', address: 'Campridge, Ames Street 3' },
     ])
   },
-  'test employee with non comp supervisor ': (assert) => {
+  'test employee with non comp supervisor ': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       supervisor: DB.string,
@@ -153,7 +153,7 @@ export const testMore = {
     const supervisor = new Employee()
 
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           employee: employee.name,
           supervisor: supervisor.name,

--- a/test/query-builder.spec.js
+++ b/test/query-builder.spec.js
@@ -29,7 +29,7 @@ export const testQueryBuilder = {
       ]
     })
 
-    assert.deepEqual(query.execute(db), [
+    assert.deepEqual(await query.execute(db), [
       {
         uploadLink: 'bafy...upload',
         storeLink: 'bafy...store',

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -21,7 +21,7 @@ export const testRules = {
     const who = DB.link()
     const name = DB.string()
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         name: name,
       },
@@ -80,7 +80,7 @@ export const testRules = {
       ],
     })
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         employee: employee.name,
         coworker: coworker.name,

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -24,7 +24,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         upload: {
           cid: upload.cid,
@@ -77,7 +77,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         result: {
           upload: {
@@ -135,7 +135,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         result: [
           {

--- a/test/transact.spec.js
+++ b/test/transact.spec.js
@@ -91,7 +91,7 @@ export const testTransact = {
     //   ],
     // })
 
-    const result = DB.query(db, {
+    const result = await DB.query(db, {
       select: {
         space,
         storeUCAN,


### PR DESCRIPTION
Hi @Gozala, here's another attempt based on your guidance from my last PR. Facts are gathered (and de-duped) in advance of query evaluation with minimal async. Does this implementation align with your thinking? Appreciate any feedback.