### PR TITLE
feat!: async query and transaction interface

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { ByteView, Link as IPLDLink } from 'multiformats'
+import { Task } from './task.js'
 
-export type { ByteView }
+export type { ByteView, Task }
 
 /**
  * Generic reader interface that can be used to read `O` value form the
@@ -266,6 +267,17 @@ export type Fact = readonly [
 ]
 
 /**
+ * An atomic {@link Fact} with a `cause` field providing a causal relationship
+ * that acts like timestamp.
+ */
+export type Datum = readonly [
+  entity: Entity,
+  attribute: Attribute,
+  value: Constant,
+  cause: Entity,
+]
+
+/**
  * Set of {@link Fact}s associating several attributes with the same new entity.
  * Each key represents an `attribute` and corresponding value represents it's
  * `value`.
@@ -291,19 +303,19 @@ export interface FactsSelector {
 }
 
 export type Instruction = Variant<{
-  Associate: Fact
-  Disassociate: Fact
-  Add: Instantiation
+  Assert: Fact
+  Retract: Fact
+  Import: Instantiation
 }>
 
 export interface Transaction extends Iterable<Instruction> {}
 
-export interface Transactor {
-  transact(transaction: Transaction): Promise<Result<{}, Error>>
+export interface Transactor<Ok extends {} = {}> {
+  transact(transaction: Transaction): Task<Ok, Error>
 }
 
 export interface Querier {
-  facts(selector?: FactsSelector): Fact[]
+  scan(selector?: FactsSelector): Task<Datum[], Error>
 }
 
 export type Constraint = Variant<{

--- a/src/lib.js
+++ b/src/lib.js
@@ -9,6 +9,7 @@ import { dependencies } from './dsl.js'
 import * as Constraint from './constraint.js'
 import * as Clause from './clause.js'
 import * as Selector from './selector.js'
+import * as Task from './task.js'
 
 export * as Variable from './variable.js'
 export * from './api.js'
@@ -17,8 +18,7 @@ export * from './dsl.js'
 export * as Constant from './constant.js'
 export { and, or, match, not } from './clause.js'
 export { rule } from './rule.js'
-export { Rule }
-export { API }
+export { Rule, Task, API }
 
 const ENTITY = 0
 const ATTRIBUTE = 1
@@ -33,9 +33,18 @@ export const { select } = Constraint
  * @param {object} source
  * @param {Selection} source.select
  * @param {Iterable<API.Clause>} source.where
- * @returns {API.InferBindings<Selection>[]}
  */
-export const query = (db, { select, where }) => {
+export const query = (db, source) => Task.perform(evaluateQuery(db, source))
+
+/**
+ * @template {API.Selector} Selection
+ * @param {API.Querier} db
+ * @param {object} source
+ * @param {Selection} source.select
+ * @param {Iterable<API.Clause>} source.where
+ * @returns {Task.Task<API.InferBindings<Selection>[] , Error>}
+ */
+function* evaluateQuery(db, { select, where }) {
   const clauses = []
 
   // Flatten all the `And` clauses.
@@ -88,11 +97,13 @@ export const query = (db, { select, where }) => {
     }
   }
 
-  const matches = evaluate(db, {
+  const matches = yield* evaluate(db, {
     And: clauses.sort(byClause),
   })
 
-  return [...matches].map((match) => Selector.select(select, match))
+  const selection = [...matches].map((match) => Selector.select(select, match))
+
+  return selection
 }
 
 /**
@@ -139,24 +150,23 @@ const rateClause = (clause) => {
  * @param {API.Querier} db
  * @param {API.Clause} query
  * @param {Iterable<API.Bindings>} frames
- * @returns {Iterable<API.Bindings>}
+ * @returns {Task.Task<Iterable<API.Bindings>, Error>}
  */
 export const evaluate = function* (db, query, frames = [{}]) {
   if (query.Or) {
-    yield* evaluateOr(db, query.Or, frames)
+    return yield* evaluateOr(db, query.Or, frames)
   } else if (query.And) {
-    yield* evaluateAnd(db, query.And, frames)
+    return yield* evaluateAnd(db, query.And, frames)
   } else if (query.Not) {
-    yield* evaluateNot(db, query.Not, frames)
+    return yield* evaluateNot(db, query.Not, frames)
   } else if (query.Form) {
-    yield* evaluateForm(db, query.Form, frames)
+    return yield* evaluateForm(db, query.Form, frames)
   } else if (query.Rule) {
-    yield* evaluateRule(db, query.Rule, frames)
+    return yield* evaluateRule(db, query.Rule, frames)
   } else if (query.Is) {
-    yield* evaluateIs(db, query.Is, frames)
+    return yield* evaluateIs(db, query.Is, frames)
   } else {
-    const out = [...evaluateCase(db, query.Case, frames)]
-    yield* out
+    return yield* evaluateCase(db, query.Case, frames)
   }
 }
 
@@ -170,10 +180,10 @@ export const evaluate = function* (db, query, frames = [{}]) {
  */
 export const evaluateAnd = function* (db, conjuncts, frames) {
   for (const query of conjuncts) {
-    frames = evaluate(db, query, frames)
+    frames = yield* evaluate(db, query, frames)
   }
 
-  yield* frames
+  return frames
 }
 
 /**
@@ -183,11 +193,13 @@ export const evaluateAnd = function* (db, conjuncts, frames) {
  * @param {Iterable<API.Bindings>} frames
  */
 export const evaluateNot = function* (db, operand, frames) {
+  const matches = []
   for (const frame of frames) {
-    if (isEmpty(evaluate(db, operand, [frame]))) {
-      yield frame
+    if (isEmpty(yield* evaluate(db, operand, [frame]))) {
+      matches.push(frame)
     }
   }
+  return matches
 }
 
 /**
@@ -203,11 +215,13 @@ export const evaluateNot = function* (db, operand, frames) {
  * @param {Iterable<API.Bindings>} frames
  */
 export const evaluateForm = function* (db, form, frames) {
+  const matches = []
   for (const bindings of frames) {
     if (form.confirm(form.selector, bindings).ok) {
-      yield bindings
+      matches.push(bindings)
     }
   }
+  return matches
 }
 
 /**
@@ -231,9 +245,12 @@ export const evaluateOr = function* (db, disjuncts, frames) {
   // We copy iterable here because first disjunct will consume all the frames
   // and subsequent ones will not have any frames to work with otherwise.
   frames = [...frames]
+  const matches = []
   for (const query of disjuncts) {
-    yield* evaluate(db, query, frames)
+    const bindings = yield* evaluate(db, query, frames)
+    matches.push(...bindings)
   }
+  return matches
 }
 
 /**
@@ -242,12 +259,14 @@ export const evaluateOr = function* (db, disjuncts, frames) {
  * @param {Iterable<API.Bindings>} frames
  */
 export const evaluateIs = function* (_, [expect, actual], frames) {
+  const matches = []
   for (const bindings of frames) {
     const result = unifyMatch(expect, actual, bindings)
     if (!result.error) {
-      yield result.ok
+      matches.push(result.ok)
     }
   }
+  return matches
 }
 
 /**
@@ -258,12 +277,14 @@ export const evaluateIs = function* (_, [expect, actual], frames) {
 
 const evaluateCase = function* (db, pattern, frames) {
   // We collect facts to avoid reaching for the db on each frame.
-  const facts = [...iterateFacts(db, pattern)]
+  const facts = yield* iterateFacts(db, pattern)
+  const matches = []
   for (const bindings of frames) {
     for (const fact of facts) {
-      yield* matchFact(fact, pattern, bindings)
+      matches.push(...matchFact(fact, pattern, bindings))
     }
   }
+  return matches
 }
 
 /**
@@ -273,9 +294,12 @@ const evaluateCase = function* (db, pattern, frames) {
  * @param {Iterable<API.Bindings>} frames
  */
 const evaluateRule = function* (db, rule, frames) {
-  for (const bindings of frames) {
-    yield* matchRule(db, rule, bindings)
+  const matches = []
+  for (const frame of frames) {
+    const bindings = yield* matchRule(db, rule, frame)
+    matches.push(...bindings)
   }
+  return matches
 }
 
 /**
@@ -283,10 +307,12 @@ const evaluateRule = function* (db, rule, frames) {
  * @param {API.Pattern} pattern
  */
 const iterateFacts = (db, [entity, attribute, value]) =>
-  db.facts({
-    entity: Variable.is(entity) ? undefined : entity,
-    attribute: Variable.is(attribute) ? undefined : attribute,
-    value: Variable.is(value) ? undefined : value,
+  Task.spawn(function* () {
+    return db.facts({
+      entity: Variable.is(entity) ? undefined : entity,
+      attribute: Variable.is(attribute) ? undefined : attribute,
+      value: Variable.is(value) ? undefined : value,
+    })
   })
 
 /**
@@ -386,17 +412,20 @@ export const matchVariable = (variable, value, bindings) => {
  * @param {API.Bindings} bindings
  */
 const matchRule = function* (db, rule, bindings) {
+  const matches = []
   if (rule.rule) {
     const { match, where } = Rule.setup(rule.rule)
 
     // Unify passed rule bindings with the rule match pattern.
     const result = unifyRule(rule.input, match, bindings)
     if (!result.error) {
-      yield* evaluate(db, where, [result.ok])
+      const bindings = yield* evaluate(db, where, [result.ok])
+      matches.push(...bindings)
     }
   } else {
-    yield bindings
+    matches.push(bindings)
   }
+  return matches
 }
 
 /**

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -74,7 +74,6 @@ class Query {
   /**
    *
    * @param {API.Querier} db
-   * @returns {API.InferBindings<Selection>[]}
    */
   execute(db) {
     return query(db, this.model)

--- a/src/task.js
+++ b/src/task.js
@@ -1,0 +1,371 @@
+/* eslint-disable no-constant-condition */
+/* eslint-disable require-yield */
+import * as Task from './task/task.js'
+import { SUSPEND, RESUME } from './task/task.js'
+
+export * from './task/task.js'
+
+/**
+ * @template T
+ * @param {unknown|PromiseLike<T>} value
+ * @returns {value is PromiseLike<T>}
+ */
+const isPromiseLike = (value) =>
+  value != null &&
+  typeof (/** @type {{then?:unknown}} */ (value).then) === 'function'
+
+/**
+ * Takes a `Promise` value and returns a task that suspends until the promise
+ * is resolved and then returns the resolved value. If you pass a non-promise
+ * value it will return it back immediately, however typescript inference may
+ * get confused.
+ *
+ * @template U
+ * @param {U} source
+ * @returns {Task.Task<Awaited<U>>}
+ */
+export function* wait(source) {
+  if (isPromiseLike(source)) {
+    const invocation = yield* fork(suspend())
+    let ok
+    void source.then(
+      (out) => {
+        ok = out
+        invocation.abort(RESUME)
+      },
+      (error) => {
+        if (error instanceof AbortError) {
+          invocation.abort(error.reason)
+        } else {
+          invocation.abort(error)
+        }
+      }
+    )
+
+    yield* invocation
+
+    return /** @type {any} */ (ok)
+  } else {
+    return /** @type {any} */ (source)
+  }
+}
+
+/**
+ * Returns a task that is suspended for a given duration in milliseconds.
+ *
+ * @param {number} duration
+ * @returns {Task.Task<void>}
+ */
+export const sleep = function* (duration) {
+  let id = null
+  try {
+    const invocation = yield* fork(suspend())
+    id = setTimeout(() => invocation.abort(RESUME), duration)
+    yield* invocation
+  } finally {
+    if (id != null) {
+      clearTimeout(id)
+    }
+  }
+}
+
+export const ok = Object.assign(
+  /**
+   * Takes a {@link Task.Result} value and returns a task that return `ok` value of
+   * the successful result or throws the `error` of the failed result.
+   *
+   * @template {unknown} Ok
+   * @template {{}} Fail
+   * @param {Task.Result<Ok, Fail>} source
+   * @returns {Task.Task<Ok & {}, Fail>}
+   */
+  function* ok(source) {
+    const { ok, error } = yield* wait(source)
+    if (ok) {
+      return ok
+    } else {
+      throw error
+    }
+  },
+  {
+    /**
+     * Takes a `Promise` of the {@link Task.Result} value and returns a task that
+     * return `ok` value of the successful result or throws the `error` of the
+     * failed result. It suspends the task until the promise is resolved.
+     *
+     * @template {unknown} Ok
+     * @template {unknown} Fail
+     * @param {PromiseLike<Task.Result<Ok, Fail>>} source
+     * @returns {Task.Task<Ok & {}, Fail & {}>}
+     */
+    *wait(source) {
+      const result = yield* wait(source)
+      if (result.ok) {
+        return result.ok
+      } else {
+        throw result.error
+      }
+    },
+  }
+)
+
+/**
+ * @template {globalThis.Error} Error
+ * @param {Error} error
+ * @returns {Task.Task<never, Error>}
+ */
+export const fail = function* (error) {
+  throw error
+}
+
+/**
+ * Spawns a concurrent task and returns a
+ *
+ * @template Ok
+ * @template {globalThis.Error} Fail
+ * @template {Task.Suspend|Task.Join|Task.Throw<Fail>} Command
+ * @param {() => Task.Task<Ok, Fail, Command>} work
+ * @returns {Task.Invocation<Ok, Task.InferError<Command>>}
+ */
+export const spawn = (work) => perform(work())
+
+/**
+ * @template Ok
+ * @template {globalThis.Error} Fail
+ * @template {Task.Suspend|Task.Join|Task.Throw<Fail>} Command
+ * @param {Task.Task<Ok, Fail, Command>} task
+ * @returns {Task.Invocation<Ok, Task.InferError<Command>>}
+ */
+export const perform = (task) =>
+  /** @type {Task.Invocation<Ok, Task.InferError<Command>>} */ (
+    new Invocation(/** @type {Task.Task<Ok, Fail, Command>} */ (task))
+  )
+
+/**
+ * @template Ok
+ * @template {globalThis.Error} Fail
+ * @template {Task.Suspend|Task.Join|Task.Throw<Fail>} Command
+ * @param {Task.Task<Ok, Fail, Command>} task
+ * @returns {Task.Task<Task.Invocation<Ok, Task.InferError<Command>>>}
+ */
+export function* fork(task) {
+  return perform(task)
+}
+
+/**
+ * @returns {Task.Task<void>}
+ */
+export function* suspend() {
+  try {
+    while (true) {
+      yield SUSPEND
+    }
+  } catch (cause) {
+    if (/** @type {Task.AbortError} */ (cause).reason !== RESUME) {
+      throw cause
+    }
+  }
+}
+
+/**
+ * @template Ok
+ * @template {globalThis.Error} Fail
+ * @template {Task.Suspend|Task.Join|Task.Throw<Fail>} Command
+ * @implements {Task.Task<Ok, Fail, Command>}
+ */
+class Continue {
+  /**
+   *
+   * @param {Task.Execution<Ok, Command>} task
+   */
+  constructor(task) {
+    this.task = task
+  }
+  [Symbol.iterator]() {
+    return this.task
+  }
+}
+
+/**
+ * @template Ok
+ * @template {globalThis.Error} Fail
+ * @template {Task.Suspend|Task.Join|Task.Throw<Fail>} [Command=Task.Suspend|Task.Join|Task.Throw<Fail>]
+ * @implements {Task.Invocation<Ok, Fail>}
+ * @implements {Task.Execution<Ok, Command>}
+ * @implements {Task.Join}
+ * @implements {Promise<Ok>}
+ */
+class Invocation {
+  /**
+   * @param {Task.Task<Ok, Fail, Command>} task
+   */
+  constructor(task) {
+    /** @type {Array<Task.Suspend|Task.Throw<Fail>>} */
+    this.queue = []
+
+    this.job = task[Symbol.iterator]()
+    /** @type {Promise<Ok>} */
+    this.outcome = new Promise((succeed, fail) => {
+      this.succeed = succeed
+      this.fail = fail
+    })
+
+    /** @type {Task.Wake} */
+    this.group = this
+
+    // start a task execution on next tick
+    setImmediate(() => this.resume(), null)
+  }
+
+  /**
+   * @returns {Task.Step<Ok, Command>}
+   */
+  next() {
+    const { job, queue } = this
+    const command = queue.shift()
+    if (!command) {
+      return job.next()
+    } else if (command === SUSPEND) {
+      return { done: false, value: /** @type {Command} */ (SUSPEND) }
+    } else if ('throw' in /** @type {Task.Throw} */ (command)) {
+      return job.throw(/** @type {Task.InferError<Command>} */ (command.throw))
+    } else {
+      throw new TypeError('Invalid command')
+    }
+  }
+
+  /**
+   * @param {Ok} ok
+   * @returns
+   */
+  return(ok) {
+    return this.job.return(ok)
+  }
+
+  /**
+   *
+   * @param {Task.InferError<Command>} error
+   * @returns {Task.Step<Ok, Command>}
+   */
+  throw(error) {
+    this.queue.push(/** @type {any} */ ({ throw: error }))
+    return this.next()
+  }
+
+  wake() {
+    if (this.group === this) {
+      this.resume()
+    } else {
+      this.group.wake()
+    }
+  }
+
+  resume() {
+    while (true) {
+      try {
+        const state = this.next()
+        if (state.done) {
+          return this.succeed(state.value)
+        } else if (state.value === SUSPEND) {
+          return
+        } else if (state.value?.join) {
+          state.value.join(this)
+        } else if (state.value?.throw) {
+          this.throw(
+            /** @type {Task.InferError<Command>} */ (state.value.throw)
+          )
+        } else {
+          throw new RangeError('Invalid command')
+        }
+      } catch (error) {
+        return this.fail(error)
+      }
+    }
+  }
+
+  /**
+   * @type {Promise<Ok>['then']}
+   */
+  then(resolve, reject) {
+    return this.outcome.then(resolve, reject)
+  }
+  /**
+   * @type {Promise<Ok>['catch']}
+   */
+  catch(reject) {
+    return this.outcome.catch(reject)
+  }
+  /**
+   * @type {Promise<Ok>['finally']}
+   */
+  finally(onFinally) {
+    return this.outcome.finally(onFinally)
+  }
+
+  [Symbol.toStringTag] = 'TaskInvocation'
+
+  /**
+   * @returns {Task.Invocation<Task.Result<Ok, Task.InferError<Command>>>}
+   */
+  result() {
+    return perform(
+      wait(
+        this.then(
+          (ok) => ({ ok }),
+          (error) => ({ error })
+        )
+      )
+    )
+  }
+
+  /**
+   *
+   * @param {unknown} reason
+   */
+  abort(reason) {
+    this.queue.push(
+      /** @type {Task.Throw<Fail>} */ ({
+        throw: new AbortError(reason),
+      })
+    )
+    this.wake()
+  }
+
+  /**
+   * @param {Task.Wake} group
+   */
+  join(group) {
+    this.group = group
+  }
+
+  /**
+   * Joins the task into the currently running task.
+   *
+   * @returns {Task.Execution<Ok, Command>}
+   */
+  *[Symbol.iterator]() {
+    // eslint-disable-next-line jsdoc/no-undefined-types
+    yield /** @type {Command} */ (/** @type {Task.Join} */ (this))
+    // We wrap this in a `Continue` because yield* will call [Symbol.iterator]
+    // to get an iterator to iterate over. We wrap it in a `Continue` to avoid
+    // infinite loop.
+    return yield* new Continue(this)
+  }
+}
+
+export class AbortError extends Error {
+  /**
+   * @param {unknown} reason
+   */
+  constructor(reason) {
+    super(`Task was aborted\n${String(reason)}`)
+    this.reason = reason
+  }
+  name = /** @type {const} */ ('AbortError')
+}
+
+/** @type {<T>(callback: (context:T) => void, context:T) => unknown} */
+const setImmediate =
+  /* c8 ignore next */
+  /** @type {any}} */ (globalThis).setImmediate ||
+  ((fn, arg) => Promise.resolve(arg).then(fn))

--- a/src/task/constant.js
+++ b/src/task/constant.js
@@ -1,0 +1,2 @@
+export const SUSPEND = Symbol.for('Task.suspend')
+export const RESUME = Symbol.for('Task.resume')

--- a/src/task/task.js
+++ b/src/task/task.js
@@ -1,0 +1,1 @@
+export * from './constant.js'

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -1,0 +1,79 @@
+import type { Result } from '../api.js'
+import { SUSPEND, RESUME } from './constant.js'
+
+export { SUSPEND, RESUME, Result }
+export type Suspend = typeof SUSPEND
+
+export interface Throw<Error extends globalThis.Error = globalThis.Error> {
+  join?: never
+  throw: Error | AbortError
+}
+
+export interface Join {
+  join(group: Wake): void
+}
+
+export type Command = Suspend | Throw<Error> | Join
+
+export interface Task<
+  Ok,
+  Error extends globalThis.Error = never,
+  Command extends Suspend | Join | Throw<Error> = Suspend | Join | Throw<Error>,
+> {
+  [Symbol.iterator](): Execution<Ok, Command>
+}
+
+export interface Execution<
+  Ok extends unknown,
+  Command extends Suspend | Join | Throw<Error>,
+> {
+  throw(error: InferError<Command>): Step<Ok, Command>
+  return(ok: Ok): Step<Ok, Command>
+  next(): Step<Ok, Command>
+  [Symbol.iterator](): Execution<Ok, Command>
+}
+
+/**
+ * Wake handler which can be used to wake the suspended task.
+ */
+export interface Wake {
+  wake(): void
+}
+
+export type Step<
+  Ok extends unknown,
+  Command extends Suspend | Join | Throw<Error>,
+> = IteratorResult<Command, Ok>
+
+export type InferError<Command> = Command extends Throw<infer Error>
+  ? Error
+  : never
+
+/**
+ * Future is a type safe promise as it captures both success and error types and
+ * provides functionality to move from try/catch operating mode into `Result`
+ * based one.
+ */
+export interface Future<Ok extends unknown, Error extends globalThis.Error>
+  extends Promise<Ok> {
+  /**
+   * Returns a promise for the `Result` that captures both success or error
+   * cases.
+   */
+  result(): Invocation<Result<Ok, Error>>
+}
+
+export interface AbortError extends Error {
+  name: 'AbortError'
+  reason: unknown
+}
+
+export interface Invocation<
+  Ok extends unknown,
+  Fail extends globalThis.Error = never,
+> extends Future<Ok, Fail | AbortError>,
+    Task<Ok, Fail> {
+  abort(reason: unknown): void
+
+  [Symbol.iterator](): Execution<Ok, Suspend | Join | Throw<Fail>>
+}

--- a/test/constraint.spec.js
+++ b/test/constraint.spec.js
@@ -12,7 +12,7 @@ const db = DB.Memory.create([
  * @type {import('entail').Suite}
  */
 export const testConstraints = {
-  like: (assert) => {
+  like: async (assert) => {
     const word = DB.string()
 
     // assert.deepEqual(
@@ -46,7 +46,7 @@ export const testConstraints = {
     // )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -56,11 +56,11 @@ export const testConstraints = {
     )
   },
 
-  glob: (assert) => {
+  glob: async (assert) => {
     const word = DB.string()
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -71,7 +71,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -82,7 +82,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -93,7 +93,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -104,7 +104,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -115,7 +115,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -125,7 +125,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -141,7 +141,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },
@@ -152,7 +152,7 @@ export const testConstraints = {
     )
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: {
           word,
         },

--- a/test/implicit.spec.js
+++ b/test/implicit.spec.js
@@ -15,7 +15,7 @@ export const testImplicit = {
     const expiration = DB.integer()
     const revoked = DB._
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         space,
         can,

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -18,7 +18,7 @@ export const testDB = {
     const uploadAdd = DB.link()
     const storeAdd = DB.link()
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         uploadCID,
         storeCID,
@@ -59,7 +59,7 @@ export const testDB = {
     const e = DB.link()
 
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: { e },
         where: [DB.match([e, 'age', 42])],
       }),
@@ -68,7 +68,7 @@ export const testDB = {
 
     const x = DB.string()
     assert.deepEqual(
-      DB.query(db, {
+      await DB.query(db, {
         select: { x },
         where: [DB.match([DB._, 'likes', x])],
       }),
@@ -76,7 +76,7 @@ export const testDB = {
     )
   },
 
-  'sketch pull pattern': (assert) => {
+  'sketch pull pattern': async (assert) => {
     const Person = DB.entity({
       'person/name': DB.string,
     })
@@ -92,7 +92,7 @@ export const testDB = {
     const actor = new Person()
 
     assert.deepEqual(
-      DB.query(moviesDB, {
+      await DB.query(moviesDB, {
         select: {
           director: director['person/name'],
           movie: movie['movie/title'],
@@ -116,7 +116,7 @@ export const testDB = {
     )
 
     assert.deepEqual(
-      DB.query(moviesDB, {
+      await DB.query(moviesDB, {
         select: {
           director: director['person/name'],
           movie: movie['movie/title'],
@@ -145,7 +145,7 @@ export const testDB = {
     const directorName = DB.string()
     const movieTitle = DB.string()
 
-    const matches = DB.query(moviesDB, {
+    const matches = await DB.query(moviesDB, {
       select: {
         director: directorName,
         movie: movieTitle,
@@ -177,7 +177,7 @@ export const testDB = {
   'test facts': async (assert) => {
     const id = DB.link()
     const name = DB.string()
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name,
       },
@@ -198,7 +198,7 @@ export const testDB = {
     const supervisorName = DB.string()
     const employee = DB.link()
     const employeeName = DB.string()
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         employee: employeeName,
         supervisor: supervisorName,
@@ -232,7 +232,7 @@ export const testDB = {
       salary: DB.integer(),
     }
 
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         salary: employee.salary,
@@ -255,7 +255,7 @@ export const testDB = {
       ]
     )
 
-    const matches2 = DB.query(employeeDB, {
+    const matches2 = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         salary: employee.salary,
@@ -291,7 +291,7 @@ export const testDB = {
       name: DB.string(),
     }
 
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
         supervisor: supervisor.name,
@@ -337,7 +337,7 @@ export const testDB = {
     }
 
     // finds all people supervised by Ben Bitdiddle who are not computer programmers
-    const matches = DB.query(employeeDB, {
+    const matches = await DB.query(employeeDB, {
       select: {
         name: employee.name,
       },

--- a/test/predicates.spec.js
+++ b/test/predicates.spec.js
@@ -6,14 +6,14 @@ import { startsWith } from '../src/constraint.js'
  * @type {import('entail').Suite}
  */
 export const testMore = {
-  'test facts': (assert) => {
+  'test facts': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       job: DB.string,
     })
 
     const employee = new Employee()
-    const result = DB.query(testDB, {
+    const result = await DB.query(testDB, {
       select: {
         name: employee.name,
       },
@@ -25,7 +25,7 @@ export const testMore = {
     ])
 
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           name: employee.name,
           job: employee.job,
@@ -44,7 +44,7 @@ export const testMore = {
       ]
     )
   },
-  'test supervisor': (assert) => {
+  'test supervisor': async (assert) => {
     const Supervisor = DB.entity({
       name: DB.string,
       salary: DB.link,
@@ -59,7 +59,7 @@ export const testMore = {
     const employee = new Employee()
     const supervisor = new Supervisor()
 
-    const result = DB.query(testDB, {
+    const result = await DB.query(testDB, {
       select: {
         employee: employee.name,
         supervisor: supervisor.name,
@@ -78,7 +78,7 @@ export const testMore = {
       { employee: 'Aull DeWitt', supervisor: 'Warbucks Oliver' },
     ])
   },
-  'test salary': (assert) => {
+  'test salary': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       salary: DB.integer,
@@ -94,7 +94,7 @@ export const testMore = {
       where: [employee.salary.greater(30_000)],
     }
 
-    const result = DB.query(testDB, query)
+    const result = await DB.query(testDB, query)
 
     assert.deepEqual(result, [
       { name: 'Bitdiddle Ben', salary: 60_000 },
@@ -104,7 +104,7 @@ export const testMore = {
       { name: 'Scrooge Eben', salary: 75_000 },
     ])
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           name: employee.name,
           salary: employee.salary,
@@ -119,7 +119,7 @@ export const testMore = {
       ]
     )
   },
-  'test address': (assert) => {
+  'test address': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       address: DB.string,
@@ -137,12 +137,12 @@ export const testMore = {
       ],
     }
 
-    assert.deepEqual(DB.query(testDB, whoLivesInCambridge), [
+    assert.deepEqual(await DB.query(testDB, whoLivesInCambridge), [
       { name: 'Hacker Alyssa P', address: 'Campridge, Mass Ave 78' },
       { name: 'Fect Cy D', address: 'Campridge, Ames Street 3' },
     ])
   },
-  'test employee with non comp supervisor ': (assert) => {
+  'test employee with non comp supervisor ': async (assert) => {
     const Employee = DB.entity({
       name: DB.string,
       supervisor: DB.string,
@@ -153,7 +153,7 @@ export const testMore = {
     const supervisor = new Employee()
 
     assert.deepEqual(
-      DB.query(testDB, {
+      await DB.query(testDB, {
         select: {
           employee: employee.name,
           supervisor: supervisor.name,

--- a/test/query-builder.spec.js
+++ b/test/query-builder.spec.js
@@ -29,7 +29,7 @@ export const testQueryBuilder = {
       ]
     })
 
-    assert.deepEqual(query.execute(db), [
+    assert.deepEqual(await query.execute(db), [
       {
         uploadLink: 'bafy...upload',
         storeLink: 'bafy...store',

--- a/test/recursion.spec.js
+++ b/test/recursion.spec.js
@@ -42,7 +42,7 @@ export const testRecursion = {
 
     const name = DB.string()
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         id: each,
         name,

--- a/test/rule.spec.js
+++ b/test/rule.spec.js
@@ -21,7 +21,7 @@ export const testRules = {
     const who = DB.link()
     const name = DB.string()
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         name: name,
       },
@@ -80,7 +80,7 @@ export const testRules = {
       ],
     })
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         employee: employee.name,
         coworker: coworker.name,

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -24,7 +24,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         upload: {
           cid: upload.cid,
@@ -77,7 +77,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         result: {
           upload: {
@@ -135,7 +135,7 @@ export const testSelector = {
       space,
     }
 
-    const result = DB.query(proofsDB, {
+    const result = await DB.query(proofsDB, {
       select: {
         result: [
           {

--- a/test/task.test.js
+++ b/test/task.test.js
@@ -1,0 +1,52 @@
+import * as Task from '../src/task.js'
+
+/**
+ * @type {import('entail').Suite}
+ */
+export const taskTests = {
+  'task sleep can be aborted': async (assert) => {
+    const task = Task.perform(Task.sleep(10))
+
+    task.abort('cancel')
+
+    const result = await task.result()
+    assert.deepEqual(result.error?.reason, 'cancel')
+    assert.deepEqual(result.error?.name, 'AbortError')
+  },
+
+  'sleep awake': async (assert) => {
+    const task = Task.perform(Task.sleep(10))
+    const result = await task.result()
+    assert.deepEqual(result, { ok: undefined })
+  },
+
+  'task cancels joined task': async (assert) => {
+    let done = false
+    function* worker() {
+      yield* Task.sleep(10)
+      done = true
+    }
+
+    function* main() {
+      return yield* Task.spawn(worker)
+    }
+
+    const task = Task.perform(main())
+    task.abort('cancel')
+    const result = await task.result()
+    assert.deepEqual(result.error?.reason, 'cancel')
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    assert.deepEqual(done, false)
+  },
+
+  'test wait': async (assert) => {
+    const task = Task.spawn(function* () {
+      const value = yield* Task.wait(Promise.resolve(4))
+      return value
+    })
+
+    assert.deepEqual(await task.result(), { ok: 4 })
+  },
+}

--- a/test/transact.spec.js
+++ b/test/transact.spec.js
@@ -39,7 +39,10 @@ export const testTransact = {
     ]
 
     const db = DB.Memory.create()
-    await db.transact(ucans.map((ucan) => ({ Add: ucan })))
+    await DB.transact(
+      db,
+      ucans.map((ucan) => ({ Import: ucan }))
+    )
 
     const Capability = DB.entity({
       can: DB.string,

--- a/test/transact.spec.js
+++ b/test/transact.spec.js
@@ -91,7 +91,7 @@ export const testTransact = {
     //   ],
     // })
 
-    const result = DB.query(db, {
+    const result = await DB.query(db, {
       select: {
         space,
         storeUCAN,

--- a/test/ui.spec.js
+++ b/test/ui.spec.js
@@ -34,7 +34,7 @@ export const testBasic = {
     const input = DB.string()
     const title = DB.string()
 
-    const matches = DB.query(db, {
+    const matches = await DB.query(db, {
       select: {
         self,
         item: { title },


### PR DESCRIPTION
Changes here import simple `Task` scheduler that abstracts over sync / async operations using generators. This allows us to use library usable with sync stores without extra overhead e.g.

```js
function* demo() {
  const result = yield* DB.query(db, myQuery)
  return result
}
```

With sync store you could just `demo()` while with async store you'd have something like `await Task.perform(demo())`.

ℹ️ This is not an ideal solution, but it is a shortcut to async stores before we cane make something more sophisticated done.