### PR TITLE
feat: empty aggregates

### DIFF
--- a/test/aggregate.spec.js
+++ b/test/aggregate.spec.js
@@ -100,4 +100,30 @@ export const testAggregate = {
         },
       ])
     }),
+
+  'aggregate 0 items': (assert) =>
+    Task.spawn(function* () {
+      const groceries = DB.Link.of({ name: 'Groceries' })
+      const db = DB.Memory.create([[groceries, 'name', 'Groceries']])
+
+      const list = DB.link()
+      const item = DB.link()
+      const title = DB.string()
+      const name = DB.string()
+      const todo = DB.variable()
+
+      const match = yield* DB.query(db, {
+        select: {
+          name,
+          item: [{ todo: item, title }],
+        },
+        where: [
+          DB.match([list, 'name', name]),
+          DB.match([list, 'todo', item]),
+          DB.match([item, 'title', title]),
+        ],
+      })
+
+      assert.deepEqual(match, [{ name: 'Groceries', item: [] }])
+    }),
 }


### PR DESCRIPTION
Illustrates an unintuitive case where parent has no children and instead of query producing empty aggregate it produces no matches.