### PR TITLE
fix: add task and variable to export maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,16 @@
       "types": "./dist/src/lib.d.ts",
       "import": "./src/lib.js",
       "default": "./src/lib.js"
+    },
+    "./task": {
+      "types": "./dist/src/task.d.ts",
+      "import": "./src/task.js",
+      "default": "./src/task.js"
+    },
+    "./variable": {
+      "types": "./dist/src/variable.d.ts",
+      "import": "./src/variable.js",
+      "default": "./src/variable.js"
     }
   },
   "dependencies": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,5 @@
 import { ByteView, Link as IPLDLink } from 'multiformats'
 import { Task } from './task.js'
-import { Output } from 'entail'
 
 export type { ByteView, Task }
 


### PR DESCRIPTION
Just adds task and variable to export maps so they could be imported without having to pull everything.