### PR TITLE
chore: define query type

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -459,6 +459,20 @@ export interface Bindings extends Record<PropertyKey, Constant> {}
 //   extends Record<PropertyKey, Term | Term[] | Selector | Selector[]> {}
 export type Selector = AggregateSelector | NamedSelector
 
+/**
+ * Where clause describes the conditions that must be satisfied for the query
+ * to return a result.
+ */
+export type Where = Iterable<Clause>
+
+/**
+ * Query that can be evaluated against the database.
+ */
+export type Query<Select extends Selector> = {
+  select: Select
+  where: Where
+}
+
 export type AggregateSelector = [Selector | Term]
 
 export interface NamedSelector extends Record<PropertyKey, Selector | Term> {}

--- a/src/lib.js
+++ b/src/lib.js
@@ -26,11 +26,9 @@ export { Constraint }
 export const { select } = Constraint
 
 /**
- * @template {API.Selector} Selection
+ * @template {API.Selector} Select
  * @param {API.Querier} db
- * @param {object} source
- * @param {Selection} source.select
- * @param {Iterable<API.Clause>} source.where
+ * @param {API.Query<Select>} source
  */
 export const query = (db, source) => Task.perform(evaluateQuery(db, source))
 


### PR DESCRIPTION
Defines `Query` type so we don't have to redefine it all over the place.